### PR TITLE
Changed kotlinOptions.outputFile

### DIFF
--- a/hello_js/build.gradle
+++ b/hello_js/build.gradle
@@ -11,7 +11,7 @@ sourceSets.main.kotlin.srcDirs += '../hello_shared/src/main'
 compileKotlin2Js {
     kotlinOptions.metaInfo = true
     kotlinOptions.sourceMap = true
-    kotlinOptions.outputFile = "web/js/hello_js.js"
+    kotlinOptions.outputFile = "hello_js/web/js/hello_js.js"
     kotlinOptions.suppressWarnings = true
     kotlinOptions.verbose = true
 }


### PR DESCRIPTION
Changed `compileKotlin2Js.kotlinOptions.outputFile` from `web/js/hello_js.js` to `hello_js/web/js/hello_js.js` in order to make it generate the JavaScript files iniside the `hello_js` folder. This will let the `index.html` file recognize the files properly instead of throwing exceptions while clicking on the button.